### PR TITLE
Fix network device name fetching

### DIFF
--- a/src/prefs.py
+++ b/src/prefs.py
@@ -5,6 +5,7 @@ import gettext
 import subprocess
 import logging
 import json
+import re
 
 from xapp.GSettingsWidgets import GSettingsSwitch, GSettingsFileChooser, GSettingsComboBox
 from xapp.SettingsWidgets import SettingsWidget, SettingsPage, SettingsStack, SpinButton, Entry, Button, ComboBox
@@ -224,6 +225,10 @@ class Preferences():
             lshw_out = subprocess.check_output(["lshw", "-class", "network", "-sanitize", "-json"],
                                                stderr=subprocess.DEVNULL
                                               ).decode("utf-8")
+
+            lshw_out = re.sub("\A\s*{", "[{", lshw_out)
+            lshw_out = re.sub("}\s*{", "}, {", lshw_out)
+            lshw_out = re.sub("}\s*\\n\Z", "}]\n", lshw_out)
             j = json.loads(lshw_out)
         except:
             pass


### PR DESCRIPTION
lshw messes up its json output to not supply a valid json format for multi-network-device configs. For single-network-device machines, the json itself is valid but does not represent an array.
This fixes both cases for our use case.
Ubuntu ships with a patched version of lshw so this problem does not happen on Ubuntu or Mint. It does however happen on Fedora 35.