### PR TITLE
Implement write isolation of the incoming folder.

### DIFF
--- a/bin/meson.build
+++ b/bin/meson.build
@@ -6,5 +6,12 @@ bin_file = configure_file(
   output: 'warpinator',
   configuration: prefix_info,
 )
-
 install_data(bin_file, install_dir: get_option('bindir'))
+
+
+send_bin_file = configure_file(
+  input : 'warpinator-send.in',
+  output: 'warpinator-send',
+  configuration: prefix_info,
+)
+install_data(send_bin_file, install_dir: get_option('bindir'))

--- a/bin/warpinator-send.in
+++ b/bin/warpinator-send.in
@@ -1,0 +1,247 @@
+#!/usr/bin/python3
+
+import signal
+import argparse
+import gettext
+import setproctitle
+import json
+import os
+import sys
+import locale
+import functools
+
+import gi
+gi.require_version('Gtk', '3.0')
+
+from gi.repository import GLib, Gio, Gtk, Gdk, GdkX11
+
+src = os.path.join("@prefix@", "libexec/warpinator/")
+sys.path.insert(0, src)
+
+import config
+import dbus_service
+import util
+
+signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+# i18n
+locale.bindtextdomain(config.PACKAGE, config.localedir)
+gettext.bindtextdomain(config.PACKAGE, config.localedir)
+gettext.textdomain(config.PACKAGE)
+_ = gettext.gettext
+
+setproctitle.setproctitle("warpinator-send")
+
+class WarpinatorSender:
+    """
+    This is a standalone executable that provides a simple way
+    of controlling the screensaver via its dbus interface.
+    """
+    def __init__(self):
+        self.proxy = None
+        self.ecode = 0
+
+        parser = argparse.ArgumentParser(description='warpinator-send')
+        parser.add_argument("--list-remotes", dest="list_remotes", action='store_true',
+                            help="List online remotes as JSON (any other arguments are ignored)")
+        parser.add_argument('--remote-ident', dest="ident", action='store', default="",
+                            help="Destination remote's UUID/identity, as retrieved by --list-remotes. If omitted, you will be prompted for a destination.")
+        parser.add_argument("--xid", dest="parent_window", action='store',
+                            help="Window ID of the calling application (optional)")
+        parser.add_argument("uris", type=str, nargs="*",
+                            help="List of file URIs to be sent (required unless '--list-remotes' is called).")
+
+        args = parser.parse_args()
+
+        if not args.list_remotes and len(args.uris) == 0:
+            print("Must have at least 1 uri if --get-live-remotes is not set", file=sys.stderr)
+            parser.print_help()
+            exit(1)
+
+        self.ident = args.ident
+        self.files = args.uris
+        self.list_remotes = args.list_remotes
+
+        if args.parent_window:
+            self.parent_window = int(args.parent_window, 0)  # maybe hex, detect the base
+        else:
+            self.parent_window = None
+
+        self.popup = None
+
+        Gio.DBusProxy.new_for_bus(
+            Gio.BusType.SESSION,
+            Gio.DBusProxyFlags.DO_NOT_AUTO_START,
+            dbus_service.interface_node_info.interfaces[0],
+            "org.x.Warpinator",
+            "/org/x/Warpinator",
+            "org.x.Warpinator",
+            None,
+            self._on_proxy_ready
+        )
+
+    def _on_proxy_ready(self, object, result, data=None):
+        try:
+            self.proxy = Gio.DBusProxy.new_for_bus_finish(result);
+        except GLib.Error as e:
+            print("Can't create warpinator proxy (%d): %s" % (e.code, e.message), file=sys.stderr)
+            self.ecode = 1
+            Gtk.main_quit()
+
+        self.handle_command()
+
+    def handle_command(self):
+        if self.list_remotes:
+            self.proxy.call(
+                "ListRemotes",
+                None,
+                Gio.DBusCallFlags.NO_AUTO_START,
+                -1,
+                None,
+                self.list_remotes_command_finished
+            )
+        elif self.ident != "":
+            self.send_files_to(self.ident)
+        else:
+            self.proxy.call(
+                "ListRemotes",
+                None,
+                Gio.DBusCallFlags.NO_AUTO_START,
+                -1,
+                None,
+                self.list_remotes_for_send_finished
+            )
+
+    def send_files_command_finished(self, source, res, data=None):
+        try:
+            var = source.call_finish(res)
+        except GLib.Error as e:
+            print("Could not send files: %s" % str(e), file=sys.stderr)
+            self.ecode = 1
+
+        Gtk.main_quit()
+
+    def list_remotes_command_finished(self, source, res, data=None):
+        try:
+            var = source.call_finish(res)
+            remote_list = var[0]
+
+            dump = json.dumps(remote_list, indent=2)
+            print(dump, file=sys.stdout)
+        except GLib.Error as e:
+            print("Could not list remotes: %s" % str(e), file=sys.stderr)
+            self.ecode = 1
+
+        Gtk.main_quit()
+
+    def list_remotes_for_send_finished(self, source, res, data=None):
+        try:
+            var = source.call_finish(res)
+            remote_list = var[0]
+        except GLib.Error as e:
+            print("Could not list remotes to ask user: %s" % str(e), file=sys.stderr)
+            self.ecode = 1
+            Gtk.main_quit()
+            return
+
+        popup = Gtk.Window(type_hint=Gdk.WindowTypeHint.POPUP_MENU,
+                           destroy_with_parent=True,
+
+                           resizable=False)
+
+        if self.parent_window is None:
+            popup.set_keep_above(True)
+
+        hb = Gtk.HeaderBar(title="Warpinator",
+                           subtitle=_("Choose a recipient..."),
+                           show_close_button=True)
+        popup.set_titlebar(hb)
+
+        seat = Gdk.Display.get_default().get_default_seat()
+        pointer = seat.get_pointer()
+        screen, x, y = pointer.get_position()
+
+        popup.move(x + 5, y + 5)
+
+        remote_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, margin=4)
+        popup.add(remote_box)
+
+        button_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4, homogeneous=True)
+        remote_box.pack_start(button_box, True, True, 0)
+
+        class RemoteInfo:
+            def __init__(self, remote):
+                self.uuid = remote["uuid"]
+                self.display_name = remote["display-name"]
+                self.username = remote["username"]
+                self.hostname = remote["hostname"]
+                self.favorite = remote["favorite"]
+                self.recent_time = remote["recent-time"]
+
+        infos = []
+        for remote in remote_list:
+            infos.append(RemoteInfo(remote))
+
+        sorted_remotes = sorted(infos, key=functools.cmp_to_key(util.sort_remote_machines))
+
+        for info in sorted_remotes:
+            label = "<b>%s</b>  %s@%s" % (info.display_name, info.username, info.hostname)
+
+            button = Gtk.Button(always_show_image=True, image_position=Gtk.PositionType.RIGHT)
+
+            if info.favorite:
+                image = Gtk.Image.new_from_icon_name("starred-symbolic", Gtk.IconSize.BUTTON)
+            elif info.recent_time > 0:
+                image = Gtk.Image.new_from_icon_name("document-open-recent-symbolic", Gtk.IconSize.BUTTON)
+            else:
+                image = None
+
+            box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+            box.pack_start(Gtk.Label(label=label, use_markup=True), True, True, 6)
+            if image is not None:
+                box.pack_end(image, False, False, 6)
+            box.show_all()
+
+            button.set_image(box)
+            button_box.add(button)
+            button.connect("clicked", self.remote_selected, info.uuid)
+
+        self.popup = popup
+        self.popup.connect("delete-event", self.on_delete_popup)
+        self.popup.connect("realize", self.on_popup_realize)
+        self.popup.show_all()
+        self.popup.present()
+
+    def on_popup_realize(self, window):
+        if self.parent_window:
+            parent = GdkX11.X11Window.foreign_new_for_display(Gdk.Display.get_default(), self.parent_window)
+            if parent is not None:
+                window.get_window().set_transient_for(parent)
+
+    def on_delete_popup(self, window, event, data=None):
+        self.ecode = 1
+        Gtk.main_quit()
+
+        return Gdk.EVENT_PROPAGATE
+
+    def remote_selected(self, button, ident):
+        self.popup.destroy()
+        self.send_files_to(ident)
+
+    def send_files_to(self, ident):
+        files_var = GLib.Variant.new_array(None, [GLib.Variant.new_string(uri) for uri in self.files])
+        full_var = GLib.Variant("(sas)", [ident, files_var])
+
+        self.proxy.call(
+            "SendFiles",
+            full_var,
+            Gio.DBusCallFlags.NO_AUTO_START,
+            -1,
+            None,
+            self.send_files_command_finished
+        )
+
+if __name__ == "__main__":
+    sender = WarpinatorSender()
+    Gtk.main()
+    exit(sender.ecode)

--- a/bin/warpinator.in
+++ b/bin/warpinator.in
@@ -3,30 +3,183 @@
 import sys
 import os
 import argparse
+import subprocess
+from pathlib import Path
 
 from gi.repository import Gio, GLib
-sys.path.insert(0, os.path.join("@prefix@", "libexec/warpinator/"))
+
+# Don't let warpinator run as root
+if os.getuid() == 0:
+    print("Warpinator should not be run as root. Please run it in user mode.")
+    sys.exit(1)
+
+src = os.path.join("@prefix@", "libexec/warpinator/")
+sys.path.insert(0, src)
+starter_path = os.path.join(src, "launcher.py")
 
 # Secure mode enforcement
 import prefs
+enforcer = prefs.SecureModePrefsBlocker()
 
-parser = argparse.ArgumentParser(description="Send and Receive Files across the Network")
+mode_help="""
+Modes:
+
+Warpinator can isolate the incoming folder so that files being received will be unable
+to modify anything outside of it (for instance, using relative symbolic links).
+
+landlock: only available with kernel >= 5.13, and only if enabled. Warpinator will run like normal,
+but individual transfers will be locked inside the incoming folder.
+
+bubblewrap: requires the bubblewrap package. Warpinator run in a sandbox (similar to Flatpaks). Only
+the incoming folder will be writable. Other locations will be read-only, including the user's
+home. Changing the incoming folder location will require a restart.
+
+legacy: Warpinator will run without any sort of protection, though some effort will still be made to
+detect relative links.
+
+Warpinator ordinarily will choose which mode to use automatically, depending on what's available. It
+will always prefer landlock over bubblewrap, with legacy as a last resort.
+ 
+"""
+
+parser = argparse.ArgumentParser(description="Send and Receive Files across the Network",
+                                 formatter_class=argparse.RawDescriptionHelpFormatter, epilog=mode_help)
 parser.add_argument("-d", "--debug", help="Print debugging information.",
                     action="store_true")
 parser.add_argument("-a", "--autostart", help="Exit if (dconf) org.x.warpinator.preferences 'autostart' is false.",
                     action="store_true")
+parser.add_argument("-m", "--mode", help="Specify a sandbox method instead of letting Warpinator decide.",
+                    action="store", choices=("legacy", "bubblewrap", "landlock"))
 args = parser.parse_args()
 
 if args.autostart:
     if not prefs.get_should_autostart():
         sys.exit(0)
-
 del sys.argv[1:]
 
-try:
-    import warpinator
-    sys.exit(warpinator.main(debug=args.debug))
-except Exception as e:
-    print(e)
-    sys.exit(1)
+if args.debug:
+    GLib.setenv("WARPINATOR_DEBUG", "1", True)
 
+GLib.setenv("PYTHONPATH", ";".join(sys.path), True)
+
+# See what we're capable of
+supported_modes = ["legacy"]
+
+if GLib.find_program_in_path("bwrap"):
+    supported_modes.insert(0, "bubblewrap")
+else:
+    if args.debug:
+        print("Bubblewrap (bwrap) not found")
+try:
+    import landlock
+    landlock.landlock_abi_version()
+    supported_modes.insert(0, "landlock")
+except ModuleNotFoundError as e:
+    if args.debug:
+        print("Landlock support unavailable - landlock python module not found (https://github.com/Edward-Knight/landlock)")
+except landlock.SyscallError as e:
+    if args.debug:
+        print("Landlock support unavailable: %s" % str(e))
+
+if args.mode:
+    if args.mode in supported_modes:
+        sandbox_mode = args.mode
+    else:
+        print("'%s' mode is not available, using '%s' instead" % (args.mode, supported_modes[0]))
+        sandbox_mode = supported_modes[0]
+else:
+    sandbox_mode = supported_modes[0]
+
+GLib.setenv("WARPINATOR_SANDBOX_MODE", sandbox_mode, True)
+
+if sandbox_mode in ("legacy, landlock"):
+    if sandbox_mode == "landlock":
+        print("Using landlock for incoming file isolation")
+    else:
+        print("Running without incoming file isolation")
+
+    launch_args = [
+        "/bin/python3", starter_path
+    ]
+else:
+    print("Using bubblewrap for incoming file isolation. Write access for the application will be limited to the save directory only.")
+
+    home = Path.home().as_posix()
+
+    try:
+        rundir = os.environ["XDG_RUNTIME_DIR"]
+    except KeyError:
+        rundir = "/run/user/%d" % os.getuid()
+
+    try:
+        rundir_bus = os.environ["DBUS_SESSION_BUS_ADDRESS"].replace("unix:path=", "")
+    except:
+        rundir_bus = rundir + "/bus"
+
+    launch_args = []
+    launch_args += ["/bin/bwrap"]
+    # Bind necessary system dirs
+    launch_args += ["--ro-bind",         "/etc",                                            "/etc"]
+    launch_args += ["--ro-bind",         "/media",                                          "/media"]
+    launch_args += ["--ro-bind",         "/usr",                                            "/usr"]
+    launch_args += ["--ro-bind",         home,                                              home]
+    launch_args += ["--proc",            "/proc"]
+    launch_args += ["--dev",             "/dev"]
+
+    launch_args += ["--ro-bind",         rundir,                                            rundir]
+    launch_args += ["--bind",            rundir + "/dconf",                                 rundir + "/dconf"]
+    launch_args += ["--bind",            rundir + "/dbus-1",                                rundir + "/dbus-1"]
+    launch_args += ["--bind",            rundir + "/gvfsd",                                 rundir + "/gvfsd"]
+    launch_args += ["--bind",            rundir_bus,                                        rundir_bus]
+
+    # Use clean tmp folders
+    launch_args += ["--dir",             "/tmp"]
+    launch_args += ["--dir",             "/var"]
+    launch_args += ["--symlink",         "/tmp",                                            "/var/tmp"]
+
+    # usrmerge links
+    launch_args += ["--symlink",         "usr/lib",                                         "/lib"]
+    launch_args += ["--symlink",         "usr/lib32",                                       "/lib32"]
+    launch_args += ["--symlink",         "usr/libx32",                                      "/libx32"]
+    launch_args += ["--symlink",         "usr/lib64",                                       "/lib64"]
+    launch_args += ["--symlink",         "usr/bin",                                         "/bin"]
+    launch_args += ["--symlink",         "usr/sbin",                                        "/sbin"]
+
+    # Keep the save path the same. (r/w)
+    launch_args += ["--bind",            "#save_path#",                                     "#save_path#"]
+
+    # The following two items aren't necessary if org.freedesktop.FileManager1 works properly - in that case,
+    # the file manager is launched outside of the sandbox. If that fails, and the file manager isn't already running,
+    # it will spawn inside the sandbox and be restricted the same as Warpinator.
+
+    # For thumbnails mainly - they're fairly small, and nemo complains if a cache isn't there and writable
+    launch_args += ["--tmpfs",           GLib.get_user_cache_dir()]
+    # caja requires ~/.config/caja be r/w or else it won't start.
+    launch_args += ["--tmpfs",           home + "/.config/caja"]
+
+    launch_args += ["--die-with-parent"]
+    # launch_args += ["/bin/sh"]
+    launch_args += ["/bin/python3",      starter_path]
+
+try:
+    while True:
+        try:
+            real_args = [arg.replace("#save_path#", prefs.get_save_path()) for arg in launch_args]
+            if args.debug and sandbox_mode == "bubblewrap":
+                print()
+                print(" ".join(real_args[:-2]).replace("--", "\n--"))
+                print(" ".join(real_args[-2:]))
+            ret = subprocess.run(real_args).returncode
+        except KeyboardInterrupt:
+            ret = 1
+            break
+
+        # Special code for restarting so the save path can be updated (bubblewrap mode).
+        if ret == 100:
+            continue
+        break
+
+    sys.exit(ret)
+except subprocess.CalledProcessError as e:
+    print("Error launching warpinator: %s", str(e))
+    sys.exit(1)

--- a/data/meson.build
+++ b/data/meson.build
@@ -63,3 +63,16 @@ appdata = i18n.merge_file(
     install_dir: join_paths(get_option('datadir'), 'metainfo'),
     install: true,
 )
+
+nemo_action = i18n.merge_file(
+    input: 'warpinator-send.nemo_action.in',
+    output: 'warpinator-send.nemo_action',
+    type: 'desktop',
+    po_dir: join_paths(meson_source_root, 'po'),
+    install_dir: join_paths(get_option('datadir'), 'nemo', 'actions'),
+    install: true,
+)
+
+install_data('warpinator-send-check',
+    install_dir: join_paths(get_option('datadir'), 'nemo', 'actions')
+)

--- a/data/meson.build
+++ b/data/meson.build
@@ -13,7 +13,7 @@ i18n.merge_file(
     ),
     output: '@0@.desktop'.format(desktop_id),
     type: 'desktop',
-    po_dir: join_paths(meson.source_root(), 'po'),
+    po_dir: join_paths(meson_source_root, 'po'),
     install: true,
     install_dir: join_paths(get_option('datadir'), 'applications'),
 )
@@ -38,7 +38,7 @@ if include_firewall_mod
         ),
         output: 'org.x.warpinator.policy',
         type: 'xml',
-        po_dir: join_paths(meson.source_root(), 'po'),
+        po_dir: join_paths(meson_source_root, 'po'),
         install_dir: join_paths(get_option('datadir'), 'polkit-1', 'actions'),
         install: true,
     )
@@ -59,7 +59,7 @@ appdata = i18n.merge_file(
     ),
     output: '@0@.appdata.xml'.format(desktop_id),
     type: 'xml',
-    po_dir: join_paths(meson.source_root(), 'po'),
+    po_dir: join_paths(meson_source_root, 'po'),
     install_dir: join_paths(get_option('datadir'), 'metainfo'),
     install: true,
 )

--- a/data/org.x.Warpinator.gschema.xml
+++ b/data/org.x.Warpinator.gschema.xml
@@ -90,6 +90,13 @@
       <default>100</default>
       <summary>Minimum free space (in mb) allowed in the save location</summary>
       <description>If a transfer would cause the save location's free space to drop below this value, the transfer is refused</description>
+    <key name="group-code" type="s">
+      <default>'Warpinator'</default>
+      <summary>The group code to share between machines that wish to connect.</summary>
+    </key>
+    <key name="connect-id" type="s">
+      <default>''</default>
+      <summary>The unique identifier used for discovery on the network, starting with your hostname. This is automatically generated, though it can be changed (max length is 63 characters).</summary>
     </key>
 
   </schema>

--- a/data/org.x.Warpinator.gschema.xml
+++ b/data/org.x.Warpinator.gschema.xml
@@ -87,9 +87,10 @@
       <summary>Size (in kb) of each block of data sent over the network. Max is 4094</summary>
     </key>
     <key name="minimum-free-space" type="u">
-      <default>100</default>
-      <summary>Minimum free space (in mb) allowed in the save location</summary>
-      <description>If a transfer would cause the save location's free space to drop below this value, the transfer is refused</description>
+      <default>250</default>
+      <summary>Minimum free space (in mb) to reserve in the save location</summary>
+      <description>If the available space on the incoming folder's drive goes below this, existing transfers will be aborted. You will also be notified if a new transfer might cause the available space to drop below this threshold.</description>
+    </key>
     <key name="group-code" type="s">
       <default>'Warpinator'</default>
       <summary>The group code to share between machines that wish to connect.</summary>

--- a/data/org.x.Warpinator.xml
+++ b/data/org.x.Warpinator.xml
@@ -1,0 +1,15 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+                      "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- GDBus 2.48.1 -->
+<node>
+  <interface name='org.x.Warpinator'>
+    <method name='ListRemotes'>
+      <!-- ident, display_name, user_name, hostname -->
+      <arg type='a(ssss)' name='remotes' direction='out'/>
+    </method>
+    <method name='SendFiles'>
+      <arg type='s' name='remote_uuid' direction='in'/>
+      <arg type='as' name='uri_list' direction='in'/>
+    </method>
+  </interface>
+</node>

--- a/data/warpinator-send-check
+++ b/data/warpinator-send-check
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+
+import sys
+import json
+import subprocess
+
+from gi.repository import Gio, GLib
+
+try:
+    reply = Gio.DBusConnection.call_sync(
+        Gio.bus_get_sync(Gio.BusType.SESSION, None),
+        "org.x.Warpinator",
+        "/org/x/Warpinator",
+        "org.x.Warpinator",
+        "ListRemotes",
+        None,
+        GLib.VariantType("(aa{sv})"),
+        Gio.DBusCallFlags.NO_AUTO_START,
+        2000,
+        None
+    )
+
+    remote_list = reply[0]
+    exit(0 if len(remote_list) > 0 else 1)
+except GLib.Error as e:
+    if e.code != Gio.DBusError.NAME_HAS_NO_OWNER:
+        print("warpinator-send-check error %d: %s" % (e.code, e.message), file=sys.stderr)
+
+exit(1)

--- a/data/warpinator-send.nemo_action.in
+++ b/data/warpinator-send.nemo_action.in
@@ -1,0 +1,9 @@
+[Nemo Action]
+Active=true
+Name=Send with Warpinator
+Comment=Send a file to someone using Warpinator
+Exec=warpinator-send --xid %X %U
+Selection=notnone
+Extensions=any
+Icon-Name=org.x.Warpinator-symbolic
+Conditions=exec <warpinator-send-check>;

--- a/debian/warpinator.debhelper.log
+++ b/debian/warpinator.debhelper.log
@@ -1,0 +1,1 @@
+dh_auto_configure

--- a/install-scripts/meson_install_bin_script.sh
+++ b/install-scripts/meson_install_bin_script.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
 chmod a+x "${DESTDIR}/${MESON_INSTALL_PREFIX}/bin/warpinator"
+chmod a+x "${DESTDIR}/${MESON_INSTALL_PREFIX}/bin/warpinator-send"
+chmod a+x "${DESTDIR}/${MESON_INSTALL_PREFIX}/share/nemo/actions/warpinator-send-check"

--- a/makepot
+++ b/makepot
@@ -8,6 +8,8 @@ xgettext --package-name=warpinator --language=Python -c --join-existing --add-co
          --output=warpinator.pot --files-from=src/gettext_files
 xgettext --package-name=warpinator --language=Desktop --join-existing \
           -k --keyword=Comment --output=warpinator.pot data/org.x.Warpinator.desktop.in.in
+xgettext --package-name=warpinator --language=Desktop --join-existing \
+         --output=warpinator.pot data/warpinator-send.nemo_action.in
 xgettext --package-name=warpinator --its=/usr/share/gettext/its/polkit.its --join-existing --add-comments \
          --output=warpinator.pot data/org.x.warpinator.policy.in.in
 xgettext --package-name=warpinator --its=/usr/share/gettext/its/metainfo.its --join-existing --add-comments \

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,8 @@ install_datadir = join_paths(get_option('prefix'), get_option('datadir'), 'warpi
 install_libdir = join_paths(get_option('prefix'), get_option('libexecdir'), 'warpinator')
 install_bindir = join_paths(get_option('prefix'), get_option('bindir'))
 
+meson_source_root = meson.current_source_dir()
+
 include_firewall_mod = get_option('include-firewall-mod')
 bundle_zeroconf = get_option('bundle-zeroconf')
 
@@ -32,7 +34,7 @@ message('\n'.join(['',
 '    @0@-@1@'.format(meson.project_name(), meson.project_version()),
 '',
 '    prefix:                 @0@'.format(get_option('prefix')),
-'    source code location:   @0@'.format(meson.source_root()),
+'    source code location:   @0@'.format(meson_source_root),
 '',
 '    building for flatpak:   @0@'.format(get_option('flatpak-build')),
 '    including ufw script:   @0@'.format(include_firewall_mod),

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,7 @@ meson_source_root = meson.current_source_dir()
 
 include_firewall_mod = get_option('include-firewall-mod')
 bundle_zeroconf = get_option('bundle-zeroconf')
+bundle_landlock = get_option('bundle-landlock')
 
 # grpc 1.30.2 on ubuntu 22.04 is broken
 pymod = import('python')
@@ -39,6 +40,7 @@ message('\n'.join(['',
 '    building for flatpak:   @0@'.format(get_option('flatpak-build')),
 '    including ufw script:   @0@'.format(include_firewall_mod),
 '    bundling zeroconf:      @0@'.format(bundle_zeroconf and not get_option('flatpak-build')),
+'    bundling landlock:      @0@'.format(bundle_landlock),
 '    bundling grpc:          @0@'.format(bundle_grpc),
 '',
 ]))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,6 +14,12 @@ option('bundle-zeroconf',
     description: 'python-zeroconf is actively developed, with api changes/breaks occasionally - it is safer to bundle a static version where permitted.'
 )
 
+option('bundle-landlock',
+    type: 'boolean',
+    value: true,
+    description: 'Include the landlock python module (https://github.com/Edward-Knight/landlock).'
+)
+
 option('bundle-grpc-with-py310',
     type: 'boolean',
     value: false,

--- a/resources/main-window.ui
+++ b/resources/main-window.ui
@@ -124,8 +124,8 @@
           <object class="GtkBox" id="app_status_bar">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="margin-left">10</property>
-            <property name="margin-right">10</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
             <property name="margin-bottom">6</property>
             <property name="spacing">6</property>
             <child>
@@ -196,8 +196,8 @@
               <object class="GtkBox" id="overview_box">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">10</property>
-                <property name="margin-right">10</property>
+                <property name="margin-start">10</property>
+                <property name="margin-end">10</property>
                 <property name="margin-top">6</property>
                 <property name="margin-bottom">6</property>
                 <property name="vexpand">True</property>
@@ -1116,7 +1116,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">center</property>
-                        <property name="label" translatable="yes">This folder is inaccessible or does not exist.  Please select a new location in Preferences or ensure that the current one is mounted.</property>
+                        <property name="label" translatable="yes">This folder is either inaccessible or forbidden to save files to.  Please select a new location in Preferences and ensure that it is accessible.</property>
                         <property name="wrap">True</property>
                         <property name="max-width-chars">60</property>
                       </object>
@@ -1255,6 +1255,268 @@
               <packing>
                 <property name="name">shutdown</property>
                 <property name="position">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="restart_box">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="vexpand">True</property>
+                <property name="border-width">10</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="valign">center</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">10</property>
+                    <child>
+                      <object class="GtkImage" id="app_restart_icon">
+                        <property name="can-focus">False</property>
+                        <property name="no-show-all">True</property>
+                        <property name="icon-name">dialog-warning-symbolic</property>
+                        <property name="icon_size">6</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinner" id="app_restart_spinner">
+                        <property name="height-request">50</property>
+                        <property name="can-focus">False</property>
+                        <property name="no-show-all">True</property>
+                        <property name="active">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">center</property>
+                        <property name="label" translatable="yes">Restart required</property>
+                        <property name="max-width-chars">60</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                          <attribute name="scale" value="1.2"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Warpinator needs to restart before the new save directory can be used</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="app_restart_button">
+                        <property name="label" translatable="yes">Restart</property>
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="halign">center</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="app_restart_ops_count_label">
+                        <property name="can-focus">False</property>
+                        <property name="no-show-all">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">5</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">restart</property>
+                <property name="title" translatable="yes">page0</property>
+                <property name="position">8</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="no_disk_space_box">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="vexpand">True</property>
+                <property name="border-width">10</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="valign">center</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="icon-name">folder-symbolic</property>
+                        <property name="icon_size">6</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">center</property>
+                        <property name="label" translatable="yes">Disk Full</property>
+                        <property name="max-width-chars">60</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                          <attribute name="scale" value="1.2"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="no_disk_space_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">center</property>
+                        <property name="label"> Only xx is available (xx reserved).</property>
+                        <property name="ellipsize">middle</property>
+                        <property name="single-line-mode">True</property>
+                        <property name="max-width-chars">60</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">center</property>
+                        <property name="label" translatable="yes">There is insufficient space available in the save location. You need to delete some files, decrease the minimum free space in preferences or choose a new location.</property>
+                        <property name="wrap">True</property>
+                        <property name="max-width-chars">60</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButtonBox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="layout-style">center</property>
+                        <child>
+                          <object class="GtkButton" id="no_disk_space_trash_button">
+                            <property name="label" translatable="yes">Empty trash</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <property name="no-show-all">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="no_disk_space_open_save_button">
+                            <property name="label" translatable="yes">Open save folder</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="no_disk_space_baobab_button">
+                            <property name="label" translatable="yes">Examine disk usage</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <property name="no-show-all">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <style>
+                          <class name="linked"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">False</property>
+                        <property name="padding">10</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">no-disk-space</property>
+                <property name="title" translatable="yes">no-disk-space</property>
+                <property name="position">9</property>
               </packing>
             </child>
           </object>

--- a/resources/meson.build
+++ b/resources/meson.build
@@ -3,7 +3,7 @@ data = [
   'main-window.ui',
   'op-item.ui',
   'overview-button.ui',
-  'prefs-window.ui',
+  'prefs-window.ui'
 ]
 
 install_data(data,

--- a/src/auth.py
+++ b/src/auth.py
@@ -27,17 +27,7 @@ import prefs
 day = datetime.timedelta(1, 0, 0)
 EXPIRE_TIME = 30 * day
 
-DEFAULT_GROUP_CODE = "Warpinator"
-KEYFILE_GROUP_NAME = "warpinator"
-KEYFILE_CODE_KEY = "code"
-KEYFILE_UUID_KEY = "connect_id"
-CONFIG_FILE_NAME = ".group"
-
-CONFIG_FOLDER = os.path.join(GLib.get_user_config_dir(), "warpinator")
-os.makedirs(CONFIG_FOLDER, exist_ok=True)
-
 singleton = None
-keyfile = None
 
 def get_singleton():
     global singleton
@@ -47,79 +37,6 @@ def get_singleton():
 
     return singleton
 
-def _ensure_keyfile_loaded():
-    global keyfile
-
-    if keyfile is not None:
-        return
-
-    path = Path(os.path.join(CONFIG_FOLDER, CONFIG_FILE_NAME))
-    keyfile = GLib.KeyFile()
-
-    try:
-        keyfile.load_from_file(path.as_posix(), GLib.KeyFileFlags.NONE)
-    except GLib.Error as e:
-        if e.code == GLib.FileError.NOENT:
-            logging.debug("Auth: No group code file, making one.")
-            path.touch()
-        else:
-            logging.debug("Auth: Could not load existing keyfile (%s): %s" %(CONFIG_FOLDER, e.message))
-            path.unlink()
-            path.touch()
-
-def _save_keyfile():
-    _ensure_keyfile_loaded()
-    global keyfile
-
-    keyfile_bytes = bytes(keyfile.to_data()[0], "utf-8")
-
-    path = Path(os.path.join(CONFIG_FOLDER, CONFIG_FILE_NAME))
-
-    try:
-        path.unlink()
-    except OSError:
-        pass
-
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-    mode = stat.S_IRUSR | stat.S_IWUSR
-    umask = 0o777 ^ mode  # Prevents always downgrading umask to 0.
-
-    umask_original = os.umask(umask)
-
-    try:
-        fdesc = os.open(path, flags, mode)
-    finally:
-        os.umask(umask_original)
-
-    with os.fdopen(fdesc, 'wb') as f:
-        f.write(keyfile_bytes)
-
-def get_group_code():
-    reset = False
-    code = None
-
-    _ensure_keyfile_loaded()
-    global keyfile
-
-    try:
-        code = keyfile.get_string(KEYFILE_GROUP_NAME, KEYFILE_CODE_KEY)
-    except GLib.Error as e:
-        if e.code not in (GLib.KeyFileError.KEY_NOT_FOUND, GLib.KeyFileError.GROUP_NOT_FOUND):
-            logging.warn("Could not read group code from settings file (%s): %s" % (CONFIG_FOLDER, e.message))
-
-    if code is None or code == "":
-        code = DEFAULT_GROUP_CODE
-        _save_keyfile()
-        return code
-
-    if len(code) < 4:
-        logging.warn("Group Code is short, consider something longer than 8 characters.")
-
-    return code
-
-def get_secure_mode():
-    return get_group_code() != DEFAULT_GROUP_CODE
-
 class AuthManager(GObject.Object):
     __gsignals__ = {
         'group-code-changed': (GObject.SignalFlags.RUN_LAST, None, ())
@@ -128,38 +45,24 @@ class AuthManager(GObject.Object):
     def __init__(self):
         GObject.Object.__init__(self)
         self.hostname = util.get_hostname()
-        self.ident = ""
         self.ip_info = None
         self.port = None
-        self.code = ""
 
         self.private_key = None
         self.server_cert = None
 
         self.remote_certs = {}
 
+        prefs.prefs_settings.connect("changed::group-code", self.notify_group_code_changed)
+
+    def notify_group_code_changed(self, settings, key, data=None):
+        self.emit("group-code-changed")
+
     def update(self, ip_info, port):
         self.ip_info = ip_info;
         self.port = port
 
-        self._read_ident()
-        self.code = get_group_code()
         self._make_key_cert_pair()
-
-    def get_ident(self):
-        return self.ident
-
-    def update_group_code(self, code):
-        if code == self.code:
-            return
-
-        _ensure_keyfile_loaded()
-
-        self.code = code
-        keyfile.set_string(KEYFILE_GROUP_NAME, KEYFILE_CODE_KEY, code)
-        _save_keyfile()
-
-        self.emit("group-code-changed")
 
     def get_server_creds(self):
         return (self.server_private_key, self.server_pub_key)
@@ -176,7 +79,7 @@ class AuthManager(GObject.Object):
         decoded = base64.decodebytes(server_data)
 
         hasher = hashlib.sha256()
-        hasher.update(bytes(self.code, "utf-8"))
+        hasher.update(bytes(prefs.get_group_code(), "utf-8"))
         key = hasher.digest()
         decoder = secret.SecretBox(key)
 
@@ -194,7 +97,7 @@ class AuthManager(GObject.Object):
 
     def get_encoded_local_cert(self):
         hasher = hashlib.sha256()
-        hasher.update(bytes(self.code, "utf-8"))
+        hasher.update(bytes(prefs.get_group_code(), "utf-8"))
         key = hasher.digest()
 
         encoder = secret.SecretBox(key)
@@ -202,30 +105,6 @@ class AuthManager(GObject.Object):
         encrypted = encoder.encrypt(self.server_pub_key)
         encoded = base64.encodebytes(encrypted)
         return encoded
-
-    def _read_ident(self):
-        gen_new = False
-
-        _ensure_keyfile_loaded()
-        global keyfile
-
-        try:
-            self.ident = keyfile.get_string(KEYFILE_GROUP_NAME, KEYFILE_UUID_KEY)
-        except GLib.Error as e:
-            if e.code not in (GLib.KeyFileError.KEY_NOT_FOUND, GLib.KeyFileError.GROUP_NOT_FOUND):
-                logging.critical("Could not read uuid (ident) from settings file: %s" % e.message)
-
-            gen_new = True
-
-        if len(self.ident.split("-")) == 5:
-            gen_new = True
-
-        if gen_new:
-            # Max 'instance' length is 63.
-            # https://datatracker.ietf.org/doc/html/rfc6763#section-7.2
-            self.ident = "%s-%s" % (self.hostname.upper()[:42], secrets.token_hex(10).upper())
-            keyfile.set_string(KEYFILE_GROUP_NAME, KEYFILE_UUID_KEY, self.ident)
-            _save_keyfile()
 
     def _make_key_cert_pair(self):
         logging.debug("Auth: Creating server credentials")

--- a/src/auth.py
+++ b/src/auth.py
@@ -183,7 +183,7 @@ class AuthManager(GObject.Object):
         try:
             cert = decoder.decrypt(decoded)
         except nacl.exceptions.CryptoError as e:
-            print(e)
+            logging.debug("Decryption failed for remote '%s': %s" % (hostname, str(e)))
             cert = None
 
         if cert:

--- a/src/config.py.in
+++ b/src/config.py.in
@@ -13,3 +13,6 @@ VERSION="@VERSION@"
 GETTEXT_PACKAGE="@gettext_package@"
 FLATPAK_BUILD=@flatpak_build@
 RPC_API_VERSION=@RPC_API_VERSION@
+
+sandbox_mode = "legacy"
+using_landlock = False

--- a/src/dbus_service.py
+++ b/src/dbus_service.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3
+
+import logging
+
+from gi.repository import Gio, GObject, GLib
+
+interface_xml = """
+<node>
+  <interface name='org.x.Warpinator'>
+    <method name='ListRemotes'>
+      <!-- ident, display_name, user_name, hostname -->
+      <arg type='aa{sv}' name='remotes' direction='out'/>
+    </method>
+    <method name='SendFiles'>
+      <arg type='s' name='remote_uuid' direction='in'/>
+      <arg type='as' name='uri_list' direction='in'/>
+    </method>
+  </interface>
+</node>
+"""
+interface_node_info = Gio.DBusNodeInfo.new_for_xml(interface_xml)
+
+class WarpinatorDBusService(GObject.Object):
+    __gsignals__ = {
+        'handle-get-live-remotes': (GObject.SignalFlags.RUN_LAST, object, ()),
+        'handle-send-files': (GObject.SignalFlags.RUN_LAST, None, (str, object))
+    }
+
+    def __init__(self):
+        GObject.Object.__init__(self)
+        self.reg_id = 0
+
+    def register(self, connection, path):
+        self.reg_id = connection.register_object(
+            path,
+            interface_node_info.interfaces[0],
+            self._method_cb,
+            None,
+            None
+        )
+
+    def unregister(self, connection, path):
+        if self.reg_id > 0:
+            connection.unregister_object(self.reg_id)
+            self.reg_id = 0
+
+    def _method_cb(self, connection, sender, path, iface_name, method_name, params, invocation, user_data=None):
+        if method_name == "ListRemotes":
+            remotes = self.emit("handle-get-live-remotes")
+
+            builder = GLib.VariantBuilder(GLib.VariantType("aa{sv}"))
+
+            for remote in remotes:
+                vdict = GLib.VariantDict.new()
+                vdict.insert_value("uuid", GLib.Variant.new_string(remote.ident))
+                vdict.insert_value("display-name", GLib.Variant.new_string(remote.display_name))
+                vdict.insert_value("username", GLib.Variant.new_string(remote.user_name))
+                vdict.insert_value("hostname", GLib.Variant.new_string(remote.display_hostname))
+                vdict.insert_value("favorite", GLib.Variant.new_boolean(remote.favorite))
+                vdict.insert_value("recent-time", GLib.Variant.new_int64(remote.recent_time))
+                builder.add_value(vdict.end())
+            props = builder.end()
+
+            logging.debug("Received DBus call 'ListRemotes'. Returning: %s\n" % props)
+            invocation.return_value(GLib.Variant.new_tuple(props))
+        elif method_name == "SendFiles":
+            ident, files = params.unpack()
+
+            logging.debug("Received DBus call 'SendFiles'.\nRecipient: %s\nFiles: %s\n" % (ident, str(files)))
+
+            self.emit("handle-send-files", *params.unpack())
+            invocation.return_value(None)
+

--- a/src/landlock/LICENSE
+++ b/src/landlock/LICENSE
@@ -1,0 +1,31 @@
+The MIT License (MIT)
+
+Copyright (c) 2022 Edward Knight
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Files:
+
+__init__.py
+plumbing.py
+porcelain.py
+
+ref:
+https://github.com/Edward-Knight/landlock

--- a/src/landlock/__init__.py
+++ b/src/landlock/__init__.py
@@ -1,0 +1,43 @@
+"""Python interface to the Landlock Linux Security Module."""
+from typing import Optional
+
+__version__ = "1.0.0.dev4"
+
+
+class LandlockError(Exception):
+    """Generic exception for this module."""
+
+
+class SyscallError(OSError, LandlockError):
+    """Exception raised from a syscall."""
+
+    def __init__(self, *args, reason: Optional[str] = None):
+        """Augments an OSError with a "reason".
+
+        This is similar to BaseException.add_note() from Python 3.11.
+        """
+        self.reason = reason
+        super().__init__(*args)
+
+    def __str__(self):
+        super_str = super().__str__()
+        if self.reason is not None:
+            return super_str + f"\nNote: {self.reason}"
+        return super_str
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}({', '.join(self.args)}, reason={self.reason})"
+        )
+
+
+from landlock.plumbing import FSAccess, landlock_abi_version  # noqa E402
+from landlock.porcelain import Ruleset  # noqa E402
+
+__all__ = [
+    "FSAccess",
+    "landlock_abi_version",
+    "LandlockError",
+    "Ruleset",
+    "SyscallError",
+]

--- a/src/landlock/plumbing.py
+++ b/src/landlock/plumbing.py
@@ -1,0 +1,306 @@
+"""Landlock constants and syscalls."""
+import ctypes
+import enum
+import errno
+import functools
+import os
+import platform
+from typing import Callable, Optional, Tuple, TypeVar
+
+import _ctypes
+
+from landlock import SyscallError
+
+CREATE_RULESET_VERSION = 1 << 0
+
+SYSCALL_CREATE_RULESET = 444
+SYSCALL_ADD_RULE = 445
+SYSCALL_RESTRICT_SELF = 446
+PR_SET_NO_NEW_PRIVS = 38
+
+T = TypeVar("T")
+
+
+class FSAccess(enum.IntFlag):
+    """Flags representing types of file system actions.
+
+    These flags enable one to restrict a sandboxed process
+    to a set of actions on files and directories.
+
+    Files or directories opened before the sandboxing
+    are not subject to these restrictions.
+    """
+
+    # A file can only receive these access rights:
+    EXECUTE = 1 << 0
+    """Execute a file."""
+    WRITE_FILE = 1 << 1
+    """Open a file with write access."""
+    READ_FILE = 1 << 2
+    """Open a file with read access."""
+
+    # A directory can receive access rights related to files or directories.
+    # The following access right is applied to the directory itself,
+    # and the directories beneath it:
+    READ_DIR = 1 << 3
+    """Open a directory or list its content."""
+
+    # However, the following access rights only apply to the content of a directory,
+    # not the directory itself:
+    REMOVE_DIR = 1 << 4
+    """Remove an empty directory or rename one."""
+    REMOVE_FILE = 1 << 5
+    """Unlink (or rename) a file."""
+    MAKE_CHAR = 1 << 6
+    """Create (or rename or link) a character device."""
+    MAKE_DIR = 1 << 7
+    """Create (or rename) a directory."""
+    MAKE_REG = 1 << 8
+    """Create (or rename or link) a regular file."""
+    MAKE_SOCK = 1 << 9
+    """Create (or rename or link) a UNIX domain socket."""
+    MAKE_FIFO = 1 << 10
+    """Create (or rename or link) a named pipe."""
+    MAKE_BLOCK = 1 << 11
+    """Create (or rename or link) a block device."""
+    MAKE_SYM = 1 << 12
+    """Create (or rename or link) a symbolic link."""
+    REFER = 1 << 13
+    """Link or rename a file from or to a different directory.
+
+    I.e. reparent a file hierarchy.
+
+    Only available if the ABI version >= 2.
+    """
+
+    @classmethod
+    def all(cls):
+        return cls.all_file() | cls.all_dir()
+
+    @classmethod
+    def all_file(cls):
+        return cls.EXECUTE | cls.WRITE_FILE | cls.READ_FILE
+
+    @classmethod
+    def all_dir(cls):
+        flags = (
+            cls.READ_DIR
+            | cls.REMOVE_DIR
+            | cls.REMOVE_FILE
+            | cls.MAKE_CHAR
+            | cls.MAKE_DIR
+            | cls.MAKE_REG
+            | cls.MAKE_SOCK
+            | cls.MAKE_FIFO
+            | cls.MAKE_BLOCK
+            | cls.MAKE_SYM
+        )
+        # REFER only available in version 2
+        if landlock_abi_version() >= 2:
+            flags |= cls.REFER
+        return flags
+
+
+class RulesetAttr(ctypes.Structure):
+    _fields_ = [("handled_access_fs", ctypes.c_uint64)]
+
+
+class PathBeneathAttr(ctypes.Structure):
+    _fields_ = [
+        ("allowed_access", ctypes.c_uint64),
+        ("parent_fd", ctypes.c_int32),
+    ]
+
+
+def find_generic_reason_from_platform() -> Optional[str]:
+    # check OS
+    system = platform.system()
+    if system != "Linux":
+        return (
+            f"Landlock is a only available on Linux,"
+            f" it looks like you're running {system}"
+        )
+
+    # check kernel version
+    kernel_version = platform.release()
+    kernel_version_tuple = tuple(map(int, kernel_version.split("-")[0].split(".")))
+    if kernel_version_tuple < (5, 13):
+        return (
+            f"Landlock is only available in kernel 5.13 or newer,"
+            f" it looks like you're running {kernel_version}"
+        )
+
+    return None
+
+
+def find_generic_reason_from_errno(err: int) -> Optional[str]:
+    errno_to_reason = {
+        errno.ENOSYS: "Cannot find Landlock syscalls - perhaps the kernel was not built"
+        " with 'CONFIG_SECURITY_LANDLOCK=y'",
+        errno.EOPNOTSUPP: "Landlock has been disabled at boot time."
+        " The CONFIG_LSM configuration item should list 'landlock',"
+        " or, 'lsm=landlock' needs to be added the kernel's"
+        " command-line arguments (usually via your bootloader).",
+    }
+    return errno_to_reason.get(err)
+
+
+def syscall_errcheck(
+    result: T, func: _ctypes.CFuncPtr, arguments: Tuple, reason: Optional[str] = None
+) -> T:
+    err = ctypes.get_errno()
+
+    # return the result if there was no error
+    if err == 0:
+        return result
+
+    # otherwise raise a SyscallError exception
+    name = getattr(func, "name", func.__name__)
+    reason = (
+        find_generic_reason_from_platform()
+        or find_generic_reason_from_errno(err)
+        or reason
+    )
+    raise SyscallError(
+        err,
+        os.strerror(err),
+        f"Error calling {name}: {func.__name__}{arguments} = {result}",
+        reason=reason,
+    )
+
+
+def create_ruleset_errcheck(result: T, func: _ctypes.CFuncPtr, arguments: Tuple) -> T:
+    errno_to_reason = {
+        errno.EINVAL: "Unknown 'flags', or unknown access, or too small 'size'",
+        errno.E2BIG: "'attr' or 'size' inconsistencies",
+        errno.EFAULT: "'attr' or 'size' inconsistencies",
+        errno.ENOMSG: "Empty 'landlock_ruleset_attr.handled_access_fs'",
+    }
+    return syscall_errcheck(
+        result, func, arguments, errno_to_reason.get(ctypes.get_errno())
+    )
+
+
+def add_rule_errcheck(result: T, func: _ctypes.CFuncPtr, arguments: Tuple) -> T:
+    errno_to_reason = {
+        errno.EINVAL: "'flags' is not 0, or inconsistent access in the rule"
+        " (i.e. 'landlock_path_beneath_attr.allowed_access'"
+        " is not a subset of the ruleset handled accesses)",
+        errno.ENOMSG: "Empty accesses"
+        " (e.g. 'landlock_path_beneath_attr.allowed_access')",
+        errno.EBADF: "'ruleset_fd' is not a file descriptor for the current thread,"
+        " or a member of 'rule_attr' is not a file descriptor as expected",
+        errno.EBADFD: "'ruleset_fd' is not a ruleset file descriptor,"
+        " or a member of 'rule_attr' is not the expected file descriptor type",
+        errno.EPERM: "'ruleset_fd' has no write access to the underlying ruleset",
+        errno.EFAULT: "'rule_attr' inconsistency",
+    }
+    return syscall_errcheck(
+        result, func, arguments, errno_to_reason.get(ctypes.get_errno())
+    )
+
+
+def restrict_self_errcheck(result: T, func: _ctypes.CFuncPtr, arguments: Tuple) -> T:
+    errno_to_reason = {
+        errno.EINVAL: "'flags' is not 0",
+        errno.EBADF: "'ruleset_fd' is not a file descriptor for the current thread",
+        errno.EBADFD: "'ruleset_fd' is not a ruleset file descriptor",
+        errno.EPERM: "'ruleset_fd' has no read access to the underlying ruleset,"
+        " or the current thread is not running with no_new_privs,"
+        " or it doesn’t have 'CAP_SYS_ADMIN' in its namespace",
+        errno.E2BIG: "The maximum number of stacked rulesets (16)"
+        " has been reached for the current thread",
+    }
+    return syscall_errcheck(
+        result, func, arguments, errno_to_reason.get(ctypes.get_errno())
+    )
+
+
+@functools.lru_cache(1)
+def get_libc() -> ctypes.CDLL:
+    try:
+        return ctypes.CDLL(None, use_errno=True)
+    except TypeError as e:
+        if platform.system() == "Windows":
+            # on Windows we get a TypeError using name=None
+            raise SyscallError(reason=find_generic_reason_from_platform()) from e
+        raise
+
+
+@functools.lru_cache(1)
+def get_create_ruleset() -> Callable:
+    libc = get_libc()
+
+    create_ruleset = functools.partial(libc["syscall"], SYSCALL_CREATE_RULESET)
+    create_ruleset.func.name = "landlock_create_ruleset"
+    create_ruleset.func.argtypes = (
+        ctypes.c_long,
+        ctypes.POINTER(RulesetAttr),
+        ctypes.c_size_t,
+        ctypes.c_uint32,
+    )
+    create_ruleset.func.errcheck = create_ruleset_errcheck
+    create_ruleset.func.restype = ctypes.c_long
+
+    return create_ruleset
+
+
+@functools.lru_cache(1)
+def get_add_rule() -> Callable:
+    libc = get_libc()
+
+    add_rule = functools.partial(libc["syscall"], SYSCALL_ADD_RULE)
+    add_rule.func.name = "landlock_add_rule"
+    add_rule.func.argtypes = (
+        ctypes.c_long,
+        ctypes.c_int,
+        ctypes.c_uint,
+        ctypes.POINTER(PathBeneathAttr),
+        ctypes.c_uint32,
+    )
+    add_rule.func.errcheck = add_rule_errcheck
+    add_rule.func.restype = ctypes.c_long
+
+    return add_rule
+
+
+@functools.lru_cache(1)
+def get_restrict_self() -> Callable:
+    libc = get_libc()
+
+    restrict_self = functools.partial(libc["syscall"], SYSCALL_RESTRICT_SELF)
+    restrict_self.func.name = "landlock_restrict_self"
+    restrict_self.func.argtypes = (
+        ctypes.c_long,
+        ctypes.c_int,
+        ctypes.c_uint32,
+    )
+    restrict_self.func.errcheck = restrict_self_errcheck
+    restrict_self.func.restype = ctypes.c_long
+
+    return restrict_self
+
+
+@functools.lru_cache(1)
+def get_prctl() -> Callable:
+    # https://man7.org/linux/man-pages/man2/prctl.2.html
+    libc = get_libc()
+
+    prctl = libc.prctl
+    prctl.name = "prctl"
+    prctl.argtypes = (
+        ctypes.c_int,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+    )
+    prctl.errcheck = syscall_errcheck
+    prctl.restype = ctypes.c_int
+
+    return libc.prctl
+
+
+@functools.lru_cache(1)
+def landlock_abi_version() -> int:
+    return get_create_ruleset()(None, 0, CREATE_RULESET_VERSION)

--- a/src/landlock/porcelain.py
+++ b/src/landlock/porcelain.py
@@ -1,0 +1,54 @@
+import ctypes
+import dataclasses
+import os
+from typing import Optional
+
+from landlock import LandlockError
+from landlock.plumbing import (
+    PR_SET_NO_NEW_PRIVS,
+    FSAccess,
+    PathBeneathAttr,
+    RulesetAttr,
+    get_add_rule,
+    get_create_ruleset,
+    get_prctl,
+    get_restrict_self,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class Ruleset:
+    restrict_rules: FSAccess = dataclasses.field(default_factory=FSAccess.all)
+    _fd: int = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        ruleset_attr = RulesetAttr(self.restrict_rules)
+        fd = get_create_ruleset()(
+            ctypes.byref(ruleset_attr),
+            ctypes.sizeof(ruleset_attr),
+            0,
+        )
+        object.__setattr__(self, "_fd", fd)
+
+    def allow(self, *paths, rules: Optional[FSAccess] = None):
+        if rules is None:
+            rules = self.restrict_rules
+
+        for path in paths:
+            fd = os.open(path, flags=os.O_PATH)
+            try:
+                rule_attr = PathBeneathAttr(rules, fd)
+                get_add_rule()(self._fd, 1, ctypes.byref(rule_attr), 0)
+            finally:
+                os.close(fd)
+
+    def apply(self):
+        # restrict thread from gaining privileges
+        try:
+            prctl = get_prctl()
+        except Exception as e:
+            raise LandlockError("Cannot find prctl libc function") from e
+        prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)
+
+        # turn on Landlock restrictions
+        get_restrict_self()(self._fd, 0)

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import sys
+import os
+
+try:
+    import warpinator
+    ret = warpinator.main()
+
+    if "RESTART_WARPINATOR" in os.environ.keys():
+        ret = 100
+    sys.exit(ret)
+except Exception as e:
+    print(e)
+    sys.exit(1)

--- a/src/meson.build
+++ b/src/meson.build
@@ -52,3 +52,11 @@ if bundle_grpc
         strip_directory: true
     )
 endif
+
+if bundle_landlock
+    install_subdir(
+        'landlock',
+        install_dir: join_paths(install_libdir, 'landlock'),
+        strip_directory: true
+    )
+endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -24,6 +24,7 @@ libexec_py = [
   'auth.py',
   'launcher.py',
   'interceptors.py',
+  'misc.py',
   'networkmonitor.py',
   'notifications.py',
   'ops.py',

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,6 +22,7 @@ config_py = configure_file(
 libexec_py = [
   config_py,
   'auth.py',
+  'dbus_service.py',
   'launcher.py',
   'interceptors.py',
   'misc.py',

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,6 +22,7 @@ config_py = configure_file(
 libexec_py = [
   config_py,
   'auth.py',
+  'launcher.py',
   'interceptors.py',
   'networkmonitor.py',
   'notifications.py',

--- a/src/misc.py
+++ b/src/misc.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python3
+
+import threading
+import traceback
+
+from gi.repository import GLib
+
+# Used as a decorator to run things in the background
+def _async(func):
+    def wrapper(*args, **kwargs):
+        thread = threading.Thread(target=func, args=args, kwargs=kwargs)
+        thread.daemon = True
+        thread.start()
+        return thread
+    return wrapper
+
+# Used as a decorator to run things in the main loop, from another thread
+def _idle(func):
+    def wrapper(*args, **kwargs):
+        GLib.idle_add(func, *args, **kwargs)
+    return wrapper
+
+def print_stack():
+    traceback.print_stack()
+
+def check_ml(fid):
+    on_ml = threading.current_thread() == threading.main_thread()
+    print("%s on mainloop: " % fid, on_ml)

--- a/src/notifications.py
+++ b/src/notifications.py
@@ -5,6 +5,7 @@ import gettext
 from gi.repository import Gio
 
 import config
+import misc
 import util
 from util import OpStatus
 import prefs
@@ -17,7 +18,7 @@ class NewOpUserNotification():
 
         self.send_notification()
 
-    @util._idle
+    @misc._idle
     def send_notification(self):
         if prefs.get_show_notifications():
             notification = Gio.Notification.new(_("New incoming files"))
@@ -86,7 +87,7 @@ class TransferCompleteNotification():
 
         self.send_notification()
 
-    @util._idle
+    @misc._idle
     def send_notification(self):
         if prefs.get_show_notifications():
             notification = Gio.Notification.new(_("Transfer complete"))
@@ -130,7 +131,7 @@ class TransferFailedNotification():
 
         self.send_notification()
 
-    @util._idle
+    @misc._idle
     def send_notification(self):
         if prefs.get_show_notifications():
             notification = Gio.Notification.new(_("Transfer failed"))
@@ -164,7 +165,7 @@ class TransferStoppedNotification():
 
         self.send_notification()
 
-    @util._idle
+    @misc._idle
     def send_notification(self):
         if prefs.get_show_notifications():
             notification = Gio.Notification.new(_("Transfer cancelled"))

--- a/src/notifications.py
+++ b/src/notifications.py
@@ -63,7 +63,7 @@ class NewOpUserNotification():
                 notification.set_body(body)
                 notification.set_icon(Gio.ThemedIcon(name="org.x.Warpinator-symbolic"))
 
-        Gio.Application.get_default().send_notification(self.op.sender, notification)
+            Gio.Application.get_default().send_notification(self.op.sender, notification)
 
     def _notification_response(self, action, variant, op):
         response = variant.unpack()

--- a/src/ops.py
+++ b/src/ops.py
@@ -10,6 +10,7 @@ import grpc
 
 import transfers
 import prefs
+import misc
 import util
 import notifications
 from util import OpStatus, OpCommand, TransferDirection, ReceiveError
@@ -89,11 +90,11 @@ class CommonOp(GObject.Object):
         else:
             self.error_msg = str(e)
 
-    @util._idle
+    @misc._idle
     def emit_initial_setup_complete(self):
         self.emit("initial-setup-complete")
 
-    @util._idle
+    @misc._idle
     def emit_status_changed(self):
         self.emit("status-changed")
 

--- a/src/ops.py
+++ b/src/ops.py
@@ -34,6 +34,8 @@ class CommonOp(GObject.Object):
 
         self.total_size = 0
         self.total_count = 0
+        self.remaining_count = 0
+
         self.size_string = ""
         self.description = ""
         self.name_if_single = None
@@ -228,7 +230,7 @@ class ReceiveOp(CommonOp):
         self.size_string = GLib.format_size(self.total_size)
         logging.debug("Op: details: %d files, with a size of %s" % (self.total_count, self.size_string))
 
-        self.have_space = util.have_free_space(self.total_size)
+        self.have_space = util.free_space_monitor.have_enough_free(self.total_size, self.top_dir_basenames)
         self.existing = util.files_exist(self.top_dir_basenames)
         self.update_ui_info()
 

--- a/src/prefs.py
+++ b/src/prefs.py
@@ -10,7 +10,7 @@ import secrets
 import cairo
 from pathlib import Path
 
-from xapp.GSettingsWidgets import GSettingsSwitch, GSettingsFileChooser, GSettingsComboBox
+from xapp.GSettingsWidgets import GSettingsSwitch, GSettingsFileChooser, GSettingsComboBox, GSettingsSpinButton
 from xapp.SettingsWidgets import SettingsWidget, SettingsPage, SettingsStack, SpinButton, Entry, Button, ComboBox
 from gi.repository import Gtk, Gdk, Gio, GLib
 
@@ -316,6 +316,11 @@ class Preferences():
                                       size_group=size_group, dir_select=True)
         section.add_row(widget)
 
+        widget = GSettingsSpinButton(_("Reserved free space"),
+                                     PREFS_SCHEMA, MIN_FREE_SPACE_KEY, units="MB", mini=250, maxi=GLib.MAXUINT)
+
+        section.add_row(widget)
+
         widget = GSettingsSwitch(_("Require approval before accepting files"),
                                  PREFS_SCHEMA, ASK_PERMISSION_KEY)
         self.unsafe_options.append(widget)
@@ -487,6 +492,9 @@ can make it simpler to add firewall exceptions if necessary."""))
 
         self.window.show_all()
         page_stack.set_visible_child_full(page_name, transition=Gtk.StackTransitionType.NONE)
+
+    def destroy(self):
+        GLib.timeout_add(1000, self.window.destroy)
 
     def open_port(self, widget):
         self.run_port_script(self.settings.get_int(PORT_KEY), self.settings.get_int(REG_PORT_KEY))

--- a/src/prefs.py
+++ b/src/prefs.py
@@ -17,6 +17,7 @@ from gi.repository import Gtk, Gdk, Gio, GLib
 import config
 import auth
 import util
+import misc
 import networkmonitor
 
 _ = gettext.gettext
@@ -544,7 +545,7 @@ can make it simpler to add firewall exceptions if necessary."""))
 
         self.settings.apply()
 
-    @util._async
+    @misc._async
     def run_port_script(self, port, auth_port):
         command = os.path.join(config.libexecdir, "firewall", "ufw-modify")
         subprocess.run(["pkexec", command, str(port), str(auth_port)])

--- a/src/remote.py
+++ b/src/remote.py
@@ -242,12 +242,12 @@ class RemoteMachine(GObject.Object):
                     self.rpc_call(self.update_remote_machine_avatar)
 
                     # Online loop
+                    logging.info("Connected to %s" % self.display_hostname)
                     while not self.channel_keepalive.is_set():
                         self.channel_keepalive.wait(.5)
                     ##
 
                 except Exception as e:
-                    print("exception")
                     self.set_remote_status(RemoteStatus.UNREACHABLE)
 
                     if isinstance(e, grpc.FutureTimeoutError):

--- a/src/remote.py
+++ b/src/remote.py
@@ -14,6 +14,7 @@ import warp_pb2_grpc
 import interceptors
 import prefs
 import util
+import misc
 import transfers
 import auth
 from ops import SendOp, ReceiveOp
@@ -396,7 +397,7 @@ class RemoteMachine(GObject.Object):
 
         self.get_avatar_surface(loader)
 
-    @util._idle
+    @misc._idle
     def get_avatar_surface(self, loader=None):
         # This needs to be on the main loop, or else we get an x error
         if loader:
@@ -583,7 +584,7 @@ class RemoteMachine(GObject.Object):
         util.add_to_recents_if_single_selection(uri_list)
         self.rpc_call(_send_files, uri_list)
 
-    @util._idle
+    @misc._idle
     def add_op(self, op):
         if op not in self.transfer_ops:
             self.transfer_ops.append(op)
@@ -611,13 +612,13 @@ class RemoteMachine(GObject.Object):
 
         self.check_for_autostart(op)
 
-    @util._idle
+    @misc._idle
     def notify_remote_machine_of_new_op(self, op):
         if op.status == OpStatus.WAITING_PERMISSION:
             if op.direction == TransferDirection.TO_REMOTE_MACHINE:
                 self.rpc_call(self.send_transfer_op_request, op)
 
-    @util._idle
+    @misc._idle
     def check_for_autostart(self, op):
         if op.status == OpStatus.WAITING_PERMISSION:
             if isinstance(op, ReceiveOp) and \
@@ -630,7 +631,7 @@ class RemoteMachine(GObject.Object):
         self.transfer_ops.remove(op)
         self.emit_ops_changed()
 
-    @util._idle
+    @misc._idle
     def emit_ops_changed(self, op=None):
         self.emit("ops-changed")
 
@@ -645,7 +646,7 @@ class RemoteMachine(GObject.Object):
                     op.error_msg = _("Connection has been lost")
                     op.set_status(OpStatus.FAILED_UNRECOVERABLE)
 
-    @util._idle
+    @misc._idle
     def op_command_issued(self, op, command):
         # send
         if command == OpCommand.CANCEL_PERMISSION_BY_SENDER:
@@ -667,7 +668,7 @@ class RemoteMachine(GObject.Object):
         elif command == OpCommand.STOP_TRANSFER_BY_RECEIVER:
             self.rpc_call(self.stop_transfer_op, op, by_sender=False)
 
-    @util._idle
+    @misc._idle
     def op_focus(self, op):
         self.emit("focus-remote")
 

--- a/src/remote.py
+++ b/src/remote.py
@@ -570,7 +570,7 @@ class RemoteMachine(GObject.Object):
             self.stub.StopTransfer(warp_pb2.StopInfo(info=opinfo, error=op.error_msg != ""))
 
     # Op handling (run in thread pool)
-    def send_files(self, uri_list):
+    def send_files(self, uri_list, dbus_sent=False):
         def _send_files(uri_list):
             op = SendOp(
                 self.local_ident,
@@ -578,6 +578,7 @@ class RemoteMachine(GObject.Object):
                 self.display_name,
                 uri_list
             )
+            op.dbus_op = dbus_sent
             self.add_op(op)
             op.prepare_send_info()
 

--- a/src/remote.py
+++ b/src/remote.py
@@ -368,15 +368,23 @@ class RemoteMachine(GObject.Object):
             self.emit_machine_info_changed()
             self.set_remote_status(RemoteStatus.ONLINE)
         
-        future = self.stub.GetRemoteMachineInfo.future(warp_pb2.LookupName(id=self.local_ident,
-                                                                           readable_name=util.get_hostname()))
+        future = self.stub.GetRemoteMachineInfo.future(
+            warp_pb2.LookupName(
+                id=self.local_ident,
+                readable_name=util.get_hostname()
+            )
+        )
         future.add_done_callback(get_info_finished)
 
     # Run in thread pool
     def update_remote_machine_avatar(self):
         logging.debug("Remote RPC: calling GetRemoteMachineAvatar on '%s'" % self.display_hostname)
-        iterator = self.stub.GetRemoteMachineAvatar(warp_pb2.LookupName(id=self.local_ident,
-                                                                        readable_name=util.get_hostname()))
+        iterator = self.stub.GetRemoteMachineAvatar(
+            warp_pb2.LookupName(
+                id=self.local_ident,
+                readable_name=util.get_hostname()
+            )
+        )
         loader = None
         try:
             for info in iterator:
@@ -405,17 +413,22 @@ class RemoteMachine(GObject.Object):
 
         logging.debug("Remote RPC: calling TransferOpRequest on '%s'" % (self.display_hostname))
 
-        transfer_op = warp_pb2.TransferOpRequest(info=warp_pb2.OpInfo(ident=op.sender,
-                                                                      timestamp=op.start_time,
-                                                                      readable_name=util.get_hostname(),
-                                                                      use_compression=prefs.use_compression()),
-                                                 sender_name=op.sender_name,
-                                                 receiver=self.ident,
-                                                 size=op.total_size,
-                                                 count=op.total_count,
-                                                 name_if_single=op.description,
-                                                 mime_if_single=op.mime_if_single,
-                                                 top_dir_basenames=op.top_dir_basenames)
+        transfer_op = warp_pb2.TransferOpRequest(
+            info=warp_pb2.OpInfo(
+                ident=op.sender,
+                timestamp=op.start_time,
+                readable_name=util.get_hostname(),
+                use_compression=prefs.use_compression(),
+            ),
+            sender_name=op.sender_name,
+            receiver=self.ident,
+            size=op.total_size,
+            count=op.total_count,
+            name_if_single=op.description,
+            mime_if_single=op.mime_if_single,
+            top_dir_basenames=op.top_dir_basenames
+        )
+
         self.stub.ProcessTransferOpRequest(transfer_op)
 
     # Run in thread pool
@@ -426,9 +439,13 @@ class RemoteMachine(GObject.Object):
             name = op.sender
         else:
             name = self.local_ident
-        self.stub.CancelTransferOpRequest(warp_pb2.OpInfo(timestamp=op.start_time,
-                                                          ident=name,
-                                                          readable_name=util.get_hostname()))
+        self.stub.CancelTransferOpRequest(
+            warp_pb2.OpInfo(
+                timestamp=op.start_time,
+                ident=name,
+                readable_name=util.get_hostname()
+            )
+        )
         op.set_status(OpStatus.CANCELLED_PERMISSION_BY_SENDER if by_sender else OpStatus.CANCELLED_PERMISSION_BY_RECEIVER)
 
     # Run in thread pool
@@ -544,18 +561,22 @@ class RemoteMachine(GObject.Object):
         if not lost_connection:
             # We don't need to send this if it's a connection loss, the other end will handle
             # its own cleanup.
-            opinfo = warp_pb2.OpInfo(timestamp=op.start_time,
-                                     ident=name,
-                                     readable_name=util.get_hostname())
+            opinfo = warp_pb2.OpInfo(
+                timestamp=op.start_time,
+                ident=name,
+                readable_name=util.get_hostname()
+            )
             self.stub.StopTransfer(warp_pb2.StopInfo(info=opinfo, error=op.error_msg != ""))
 
     # Op handling (run in thread pool)
     def send_files(self, uri_list):
         def _send_files(uri_list):
-            op = SendOp(self.local_ident,
-                        self.ident,
-                        self.display_name,
-                        uri_list)
+            op = SendOp(
+                self.local_ident,
+                self.ident,
+                self.display_name,
+                uri_list
+            )
             self.add_op(op)
             op.prepare_send_info()
 

--- a/src/remote.py
+++ b/src/remote.py
@@ -503,31 +503,25 @@ class RemoteMachine(GObject.Object):
                           (op.total_count, GLib.format_size(op.total_size),\
                            util.precise_format_time_span(GLib.get_monotonic_time() - start_time)))
 
-            if receiver.remaining_files > 0:
-                raise ReceiveError(_("Transfer completed, but the number of files received is less than the original request size (expected %d, received %d)"
-                                       % (op.total_count, op.total_count - receiver.remaining_files)),
+            if op.remaining_count > 0:
+                raise ReceiveError("Transfer completed, but the number of files received is less than the original request size (expected %d, received %d)"
+                                       % (op.total_count, op.total_count - receiver.remaining_count),
                                    fatal=False)
+            op.set_status(OpStatus.FINISHED)
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.CANCELLED:
                 report_receive_error(None)
-                return
             else:
                 report_receive_error(e)
-                return
         except ReceiveError as e:
             if e.fatal:
                 report_receive_error(e)
-                return
             else:
                 logging.critical(str(e))
                 op.set_error(e)
                 op.set_status(OpStatus.FINISHED_WARNING)
-                return
         except Exception as e:
             report_receive_error(e)
-            return
-
-        op.set_status(OpStatus.FINISHED)
 
     # Run in thread pool
     def stop_transfer_op(self, op, by_sender=False, lost_connection=False):

--- a/src/server.py
+++ b/src/server.py
@@ -94,7 +94,7 @@ class Server(threading.Thread, warp_pb2_grpc.WarpServicer, GObject.Object):
 
         self.zeroconf = Zeroconf(interfaces=[self.ip_info.ip4_address])
 
-        self.service_ident = auth.get_singleton().get_ident()
+        self.service_ident = prefs.get_connect_id()
         self.service_name = "%s.%s" % (self.service_ident, SERVICE_TYPE)
 
         # If this process is killed (either kill or network issue), the service
@@ -279,7 +279,7 @@ class Server(threading.Thread, warp_pb2_grpc.WarpServicer, GObject.Object):
     def run(self):
         logging.debug("Server: starting server on %s (%s)" % (self.ip_info.ip4_address, self.ip_info.iface))
         logging.info("Using api version %s" % config.RPC_API_VERSION)
-        logging.info("Our uuid: %s" % auth.get_singleton().get_ident())
+        logging.info("Our uuid: %s" % prefs.get_connect_id())
 
 
         self.remote_registrar = remote_registration.Registrar(self.ip_info, self.port, self.auth_port)

--- a/src/server.py
+++ b/src/server.py
@@ -22,6 +22,7 @@ import remote
 import remote_registration
 import prefs
 import util
+import misc
 import transfers
 from ops import ReceiveOp
 from util import TransferDirection, OpStatus, RemoteStatus
@@ -369,7 +370,7 @@ class Server(threading.Thread, warp_pb2_grpc.WarpServicer, GObject.Object):
     def add_receive_op_to_remote_machine(self, op):
         self.remote_machines[op.sender].add_op(op)
 
-    @util._idle
+    @misc._idle
     def remote_ops_changed(self, remote_machine):
         self.emit("remote-machine-ops-changed", remote_machine.ident)
 
@@ -396,7 +397,7 @@ class Server(threading.Thread, warp_pb2_grpc.WarpServicer, GObject.Object):
                 if op.status == OpStatus.TRANSFERRING:
                     op.stop_transfer()
 
-    @util._idle
+    @misc._idle
     def idle_emit(self, signal, *callback_data):
         self.emit(signal, *callback_data)
 

--- a/src/server.py
+++ b/src/server.py
@@ -198,7 +198,7 @@ class Server(threading.Thread, warp_pb2_grpc.WarpServicer, GObject.Object):
             try:
                 machine = self.remote_machines[ident]
                 machine.has_zc_presence = True
-                logging.debug(">>> Discovery: existing remote: %s (%s:%d)"
+                logging.info(">>> Discovery: existing remote: %s (%s:%d)"
                                   % (machine.display_hostname, remote_ip_info.ip4_address, info.port))
 
                 # If the remote truly is the same one (our service info just dropped out
@@ -244,7 +244,7 @@ class Server(threading.Thread, warp_pb2_grpc.WarpServicer, GObject.Object):
                     if not found:
                         break
 
-                logging.debug(">>> Discovery: new remote: %s (%s:%d)"
+                logging.info(">>> Discovery: new remote: %s (%s:%d)"
                                   % (display_hostname, remote_ip_info.ip4_address, info.port))
 
                 machine = remote.RemoteMachine(ident,
@@ -257,7 +257,7 @@ class Server(threading.Thread, warp_pb2_grpc.WarpServicer, GObject.Object):
 
                 # This blocks the zeroconf thread. Registration will timeout
                 if not self.remote_registrar.register(ident, remote_hostname, remote_ip_info, info.port, auth_port, api_version) or self.server_thread_keepalive.is_set():
-                    logging.warning("Register failed, or the server was shutting down during registration, ignoring remote %s (%s:%d) auth port: %d"
+                    logging.debug("Register failed, or the server was shutting down during registration, ignoring remote %s (%s:%d) auth port: %d"
                                      % (remote_hostname, remote_ip_info.ip4_address, info.port, auth_port))
                     return
 

--- a/src/transfers.py
+++ b/src/transfers.py
@@ -181,8 +181,6 @@ class FileReceiver(GObject.Object):
         self.current_mtime = 0
         self.current_mtime_usec = 0
 
-        self.remaining_files = op.total_count
-        self.remaining_bytes = op.total_size
 
         for name in op.top_dir_basenames:
             try:
@@ -214,6 +212,8 @@ class FileReceiver(GObject.Object):
             self.current_mtime_usec = s.time.mtime_usec
         if self.remaining_files == 0:
             raise Exception(_("File count exceeds original request size"))
+            if self.op.remaining_count == 0:
+                raise ReceiveError("File count exceeds original request size")
 
         if not self.current_gfile:
             # Check for valid path (pathlib.Path resolves both relative and symbolically-linked paths)
@@ -280,7 +280,7 @@ class FileReceiver(GObject.Object):
         self.current_mode = 0
         self.current_path = None
         self.current_gfile = None
-        self.remaining_files -= 1
+        self.op.remaining_count -= 1
 
     def apply_folder_permissions(self):
         if self.preserve_perms:

--- a/src/transfers.py
+++ b/src/transfers.py
@@ -12,6 +12,7 @@ from gi.repository import GLib, Gio, GObject
 import util
 from util import FileType, ReceiveError
 import prefs
+import misc
 import warp_pb2
 
 _ = gettext.gettext
@@ -421,7 +422,7 @@ class OpProgressTracker():
         self.transfer_start_time = GLib.get_monotonic_time()
         self.last_update_time = self.transfer_start_time
 
-    @util._idle
+    @misc._idle
     def update_progress(self, size_read):
         self.total_transferred += size_read
 

--- a/src/util.py
+++ b/src/util.py
@@ -794,6 +794,10 @@ else:
 recent_manager = Gtk.RecentManager()
 
 def add_to_recents_if_single_selection(uri_list):
+    if not os.access(GLib.get_user_data_dir(), os.W_OK):
+        logging.debug("Recents storage not writable")
+        return
+
     if len(uri_list) == 1:
         try:
             recent_manager.add_item(uri_list[0])

--- a/src/util.py
+++ b/src/util.py
@@ -330,6 +330,29 @@ def open_save_folder(filename=None):
 def verify_save_folder(transient_for=None):
     return os.access(save_path, os.R_OK | os.W_OK)
 
+def test_resolved_path_safety(relative_path):
+    # Check for valid path (pathlib.Path resolves both relative and symbolically-linked paths)
+    base = Path(prefs.get_save_path())
+    unresolved = base.joinpath(relative_path)
+
+    try:
+        resolved = unresolved.resolve()
+
+        # Not outside the base folder (raises ValueError)
+        relative = resolved.relative_to(base)
+
+        # Not the base folder (../Warpinator.. )
+        try:
+            if resolved.samefile(base):
+                raise ValueError()
+        except OSError:
+            # resolved doesn't exist, so it can't be the same
+            pass
+    except RuntimeError as e:
+        raise ReceiveError("Could not resolve path '%s': %s" % str(e))
+    except ValueError:
+        raise ReceiveError("Resolved path is not valid child of the save folder: %s -> %s" % (unresolved, str(resolved)), fatal=True)
+
 def save_folder_is_native_fs():
     file = Gio.File.new_for_path(prefs.get_save_path())
     return file.is_native()

--- a/src/util.py
+++ b/src/util.py
@@ -272,24 +272,6 @@ def create_file_and_folder_picker(dialog_parent=None):
     chooser.connect("response", update_last_location)
     return chooser
 
-# Used as a decorator to run things in the background
-def _async(func):
-    def wrapper(*args, **kwargs):
-        thread = threading.Thread(target=func, args=args, kwargs=kwargs)
-        thread.daemon = True
-        thread.start()
-        return thread
-    return wrapper
-
-# Used as a decorator to run things in the main loop, from another thread
-def _idle(func):
-    def wrapper(*args, **kwargs):
-        GLib.idle_add(func, *args, **kwargs)
-    return wrapper
-
-def print_stack():
-    traceback.print_stack()
-
 def open_save_folder(filename=None):
     bus = Gio.Application.get_default().get_dbus_connection()
 
@@ -588,10 +570,6 @@ def files_exist(base_names):
             return True
 
     return False
-
-def check_ml(fid):
-    on_ml = threading.current_thread() == threading.main_thread()
-    print("%s on mainloop: " % fid, on_ml)
 
 def get_hostname():
     return GLib.get_host_name()

--- a/src/util.py
+++ b/src/util.py
@@ -328,6 +328,35 @@ def open_save_folder(filename=None):
         logging.critical("Could not open received files location: %s" % e.message)
 
 def verify_save_folder(transient_for=None):
+    # Forbidden locations for incoming files, relative to home.
+    forbidden_folders = [
+        ".config",
+        ".cache",
+        ".local",
+        ".dbus",
+        ".ssh",
+        ".mozilla",
+        ".thunderbird",
+        ".Trash-"
+    ]
+
+    save_path = Path(prefs.get_save_path()).resolve()
+    home = Path.home()
+
+    if not save_path.exists():
+        return False
+
+    if save_path.samefile(home):
+        return False
+
+    for folder in forbidden_folders:
+        test_path = home.joinpath(folder)
+        try:
+            if save_path.relative_to(test_path):
+                return False
+        except ValueError:
+            pass
+
     return os.access(save_path, os.R_OK | os.W_OK)
 
 def test_resolved_path_safety(relative_path):

--- a/src/warpinator.py
+++ b/src/warpinator.py
@@ -26,6 +26,7 @@ import prefs
 import util
 import server
 import auth
+import misc
 import networkmonitor
 from ops import SendOp, ReceiveOp
 from util import TransferDirection, OpStatus, RemoteStatus
@@ -1341,7 +1342,7 @@ class WarpApplication(Gtk.Application):
     def exit_warp(self):
         GLib.idle_add(self.quit)
 
-    @util._async
+    @misc._async
     def setup_kill_as_a_last_resort(self):
         # There are plenty of opportunities for our threads to hang due to network
         # hangs and grpc errors.  Give 10 seconds and then just end it regardless.

--- a/testing/testing.py
+++ b/testing/testing.py
@@ -4,6 +4,7 @@ from gi.repository import GLib, Gio
 import remote
 import ops
 import util
+import misc
 import transfers
 from util import RemoteStatus, OpStatus, FileType
 
@@ -145,7 +146,7 @@ def add_ops(machine):
             idle_set_op_status((op, status))
 
 
-@util._idle
+@misc._idle
 def idle_set_op_status(op_and_status):
     op, status = op_and_status
     op.set_status(status)


### PR DESCRIPTION
_(Description copied from commit 6c259fe11d69f)_

There are two methods implemented - bubblewrap (using a mount
namespace), and landlock (a Linux security module).

landlock:
- Only available since kernel 5.13, and only when the module is
  enabled. And easy check is checking your syslog for 'landlock:
  Up and running.'
- The landlock python module has been added to the source tree
  and is bundled by default.
- When a transfer begins, the thread the RPC runs on is restricted
  from accessing any location outside of the save folder.
- This restriction is permanent on the thread. Therefore, RPC threads
  cannot be recycled by a ThreadPoolExecutor. Instead we use a custom
  'NewThreadExecutor' to create new threads on-demand.
- Warpinator runs normally, otherwise.

bubblewrap:
- System and user folders are read-only. Only the save folder is
  mounted as read/write.
- If the save folder is changed in preferences, Warpinator will
  prompt that it needs to restart once there are no more active
  transfers (as the bubblewrapper will need
  to be updated).
- The org.freedesktop.FileManager1 dbus service is used if available
  when opening the save folder. If no application supports this,
  a Gio call is used, which will result in the file manager inheriting
  Warpinator's restrictive permissions, if it isn't already running.

other details:
- The type of isolation (or none) can be specified on the command
  line. Warpinator will decide automatically otherwise, preferring
  landlock over bubblewrap if both are available.
- Minimum free disk space is visibly configurable now.
- Free disk space checking will account for files being overwritten,
  as well as monitor disk space during transfers. Free space is also
  monitored during transfers.
- Certain locations are forbidden from being set as the incoming folder (home, home dot-folders).

___

To do:
- [x] Review bwrap args
- [x] Fix restarts when using bubblewrap (using shell commands does't work for this). Use a loop in /usr/bin/warpinator.
- [x] Test for vulnerabilities...
