### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -44,7 +44,12 @@ if include_firewall_mod
     )
 endif
 
-current_date = run_command('date', '+%Y-%m-%d', check: false).stdout().strip()
+current_date = run_command('sh', '-c', '''
+      SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-`date +%s`}";
+      FORMAT="+%Y-%m-%d";
+      date -u -d @"$SOURCE_DATE_EPOCH" "$FORMAT" 2>/dev/null ||
+      date -u -r  "$SOURCE_DATE_EPOCH" "$FORMAT" 2>/dev/null ||
+      date -u "$FORMAT"''', check: false).stdout().strip()
 
 appdata_conf = configuration_data()
 appdata_conf.set('appid', desktop_id)


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH` in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.
This date call works with various implementations of `date`.
Also use UTC to be independent of timezone.

note: dropping `current_date` is also an option to simplify the code.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).