### PR TITLE
Fix NameError for 'sleep'

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -86,7 +86,7 @@ class NewThreadExecutor():
                 if self.count == 0:
                     break
             logging.debug("sleep")
-            sleep(.1)
+            time.sleep(.1)
         logging.debug("NewThreadExecutor: done waiting for workers, end factory thread")
 
     def submit(self, func, *args, **kargs):


### PR DESCRIPTION
Stopping the application would yield the following stacktrace:

```python3
2023-08-20 09:55:48,289::warpinator::DEBUG: sleep -- util.py (line 88)
Exception in thread NewThreadExecutor-factory-thread:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/app/libexec/warpinator/util.py", line 89, in factory_thread_func
    sleep(.1)
NameError: name 'sleep' is not defined
```

This PR fixes this error.