### PR TITLE
Remove duplicate line in ProcessTransferOpRequest RPC handler

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -530,8 +530,6 @@ class Server(threading.Thread, warp_pb2_grpc.WarpServicer, GObject.Object):
     def ProcessTransferOpRequest(self, request, context):
         logging.debug("Server RPC: ProcessTransferOpRequest from '%s'" % request.info.readable_name)
 
-        remote_machine = self.remote_machines[request.info.ident]
-
         try:
             remote_machine = self.remote_machines[request.info.ident]
         except KeyError as e:


### PR DESCRIPTION
Please consider removing the duplicate line.
Retrieving a remote machine by ID is performed twice. This may be a typo, since the lines are the same except error handling, which is currently unreachable.