### PR TITLE
Remove iOS links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 ##### Other platforms (unofficial):
 
 - Android: https://github.com/slowscript/warpinator-android
-- iOS: https://github.com/williamMillington/warpinator-iOS (beta)
 - Windows: https://winpinator.swisz.cz
 - Windows: https://github.com/slowscript/warpinator-windows
 

--- a/resources/main-window.ui
+++ b/resources/main-window.ui
@@ -928,22 +928,6 @@
                             </child>
                             <child>
                               <object class="GtkLinkButton">
-                                <property name="label" translatable="yes">iOS</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">True</property>
-                                <property name="relief">none</property>
-                                <property name="yalign">0</property>
-                                <property name="uri">https://testflight.apple.com/join/7ndmZa31</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLinkButton">
                                 <property name="label" translatable="yes">Windows</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>


### PR DESCRIPTION
The iOS app isn't available anymore, ref: https://github.com/williamMillington/warpinator-iOS/issues/9
Fixes #202