### PR TITLE
Fix reconnecting when certificate is unchanged

### DIFF
--- a/src/remote_registration.py
+++ b/src/remote_registration.py
@@ -235,7 +235,7 @@ def register_v2(details):
     elif success == util.CertProcessingResult.CERT_UPDATED:
         logging.debug("Successfully updated registration with %s (%s:%d) - api version 2"
                              % (details.hostname, details.ip_info, details.auth_port))
-    elif success == util.CertProcessingResult.CERT_UPDATED:
+    elif success == util.CertProcessingResult.CERT_UP_TO_DATE:
         logging.debug("Certificate already up to date, nothing to do for %s (%s:%d) - api version 2"
                              % (details.hostname, details.ip_info, details.auth_port))
     return success


### PR DESCRIPTION
After 70cc5ebe7baf7aaa9498993c4d77f7169f452177 Warpinator can no longer reconnect to a rediscovered device after connection was once lost when the certificate is unchanged (remote comes back with the same IP as last time). I have fixed this by adding a condition to also reconnect when certificate is up to date and the remote is offline. The `newly_discovered` flag is to allow reconnect after server restart in which case remotes are cleared, but certificates are not (`CERT_UP_TO_DATE` and `RemoteStatus.INIT_CONNECTING`, which on its own could also mean that the remote thread is already running). Another option in this case would be to also clear the certificates on restart.

(Sorry about taking so long to finish the text message PR, hopefully I'll get to it soon)