### PR TITLE
Add python3-pkg-resources to dependencies

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -6,7 +6,6 @@ import gettext
 import logging
 import time
 import re
-import pkg_resources
 from concurrent import futures
 import time
 import ipaddress


### PR DESCRIPTION
On Debian 13.2, if the python3-pkg-resources package is not installed, warpinator fails to start and prints the following error:

```
No module named 'pkg_resources'
```

After installing python3-pkg-resources, the application launches successfully.