### PR TITLE
Do not actually link to fake website

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ________
 
 ### ⚠️ Warning: Fake/malicious website:
 
-``http://warpinator.com`` is a fake website, potentially malicious!
+`warpinator.com` is a fake website, potentially malicious!
 
 Do **NOT** download or run any software from it!
 


### PR DESCRIPTION
The readme currently creates a real link to the fake website, possibly giving it some "SEO juice" and also allowing users to click on it...

This happens even though the URL is in a Markdown `code` block. (probably some "helpful" Github Markdown extension)

Remove the `http://` part to prevent this.