### PR TITLE
Set prgname to application ID

### DIFF
--- a/src/warpinator.py
+++ b/src/warpinator.py
@@ -1424,6 +1424,8 @@ class WarpApplication(Gtk.Application):
         Gtk.Application.do_startup(self)
         logging.info("Initializing Warpinator")
 
+        GLib.set_prgname("org.x.Warpinator")
+
         prefs.prefs_settings.connect("changed::" + prefs.TRAY_ICON_KEY, self.on_prefs_changed)
 
         vt = GLib.VariantType.new("s")


### PR DESCRIPTION
Using the application ID ensures that Wayland compositors could match the window with the application and show the appropriate icon for them.

References:
- https://honk.sigxcpu.org/con/GTK__and_the_application_id.html
- https://docs.gtk.org/gtk4/migrating-3to4.html#set-a-proper-application-id