### PR TITLE
Remove inconsistent period from preferences

### DIFF
--- a/src/prefs.py
+++ b/src/prefs.py
@@ -310,7 +310,7 @@ class Preferences():
 
         section = page.add_section(_("File Transfers"))
 
-        widget = GSettingsSwitch(_("Use compression when possible."),
+        widget = GSettingsSwitch(_("Use compression when possible"),
                                  PREFS_SCHEMA, USE_COMPRESSION_KEY,
                                  tooltip=_("Warning: This may have a negative impact on performance on some faster networks."))
         section.add_row(widget)


### PR DESCRIPTION
Only a single option in Warpinator's preferences menu contains ending punctuation, so this removes it to maintain consistency.

Hopefully this won't mess up any of the translations; I'm not entirely sure how that process works.

Sorry if these types of minor changes are not welcome.