### PR TITLE
landlock: Ignore kernel patch suffixes

### DIFF
--- a/src/landlock/plumbing.py
+++ b/src/landlock/plumbing.py
@@ -146,7 +146,7 @@ def find_generic_reason_from_platform() -> Optional[str]:
 
     # check kernel version
     kernel_version = platform.release()
-    kernel_version_tuple = tuple(map(int, kernel_version.split("-")[0].split(".")))
+    kernel_version_tuple = tuple(map(int, kernel_version.split(".")[:2]))
     if kernel_version_tuple < (5, 13):
         return (
             f"Landlock is only available in kernel 5.13 or newer,"


### PR DESCRIPTION
Fixes #214.

Only the kernel major/minor version is needed for the Landlock availability check, avoiding failures on release strings such as `6.6.20+rpt-rpi-v8`.